### PR TITLE
Benutzerdefinierte Einstellungen abspalten

### DIFF
--- a/krrrcks.xml
+++ b/krrrcks.xml
@@ -439,46 +439,6 @@ alt_dopath(matches[2])</script>
             <script>-- Einstellungen (Farben etc.)</script>
             <eventHandlerList/>
             <Script isActive="yes" isFolder="no">
-                <name>Farben</name>
-                <packageName></packageName>
-                <script>-- Einstellungen fuer Farben Allgemein
-farben = {}
-farben.vg = 
-  { komm = &quot;cyan&quot;,
-    ebenen = &quot;magenta&quot;,
-    info = &quot;green&quot;,
-    alarm = &quot;white&quot;,
-    script = &quot;dark_green&quot; }
-farben.hg = 
-  { komm = &quot;black&quot;,
-    ebenen = &quot;black&quot;,
-    info = &quot;black&quot;, 
-    alarm = &quot;red&quot;,
-    script = &quot;black&quot; }
-
--- komm: Kommunikation wie teile-mit
--- ebenen: Einfaerben der &quot;normalen&quot; Ebenen
--- info: Einfaerben von Informationen des Muds (Status Gegner)
--- alarm: Alarm-Nachrichten
--- script: Nachrichten, die nicht vom Mud, sondern von einem Script stammen.
-
--- Einstellungen fuer Farben Kampfscroll
-
-function msg (type, what)
-  -- setzt VG und HG je nach Typ der Kommunikation
-  local vg = farben.vg[type]
-  local hg = farben.hg[type]
-
-  if vg and hg then
-    cecho(&quot;&lt;&quot;..vg..&quot;:&quot;..hg..&quot;&gt;&quot;..what)
-  else
-    echo(what)
-  end
-end
-</script>
-                <eventHandlerList/>
-            </Script>
-            <Script isActive="yes" isFolder="no">
                 <name>Spieler</name>
                 <packageName></packageName>
                 <script>-- Variablen zum Spieler

--- a/mapper.xml
+++ b/mapper.xml
@@ -17,21 +17,6 @@
     <!-- SCRIPTS -->
     <ScriptPackage>
         <Script isActive="yes" isFolder="no">
-            <name>Konfiguration</name>
-            <packageName></packageName>
-            <script><![CDATA[
-mapperconf = {}
-
--------------------------------------------------------
--- Benutzerdefinierte Einstellungen fuer den Mapper. --
--------------------------------------------------------
-
--- Farbe fuer Mitteilungen des Mappers
-mapperconf.color = "blue"
-                    ]]>
-            </script>
-        </Script>
-        <Script isActive="yes" isFolder="no">
             <name>Initialisierung</name>
             <packageName></packageName>
             <script><![CDATA[

--- a/mapper.xml
+++ b/mapper.xml
@@ -168,7 +168,7 @@ function isSpecialExit(name) return mapper.exitmap[name] == nil end
 -- Zur Positionierung neuer Raeume. Weist jeder Standardrichtung ein
 -- Koordinatendelta zu.
 function getExitCoordinates(name)
-    local d = 5 -- Delta fuer groessere Abstaende zwischen Raeumen.
+    local d = mapperconf.scale
     if name == "n" or name == "norden" then
         return 0, d, 0
     elseif name == "no" or name == "nordosten" then

--- a/settings.xml
+++ b/settings.xml
@@ -66,6 +66,7 @@ mapperconf = {}
 
 -- Farbe fuer Mitteilungen des Mappers
 mapperconf.color = "blue"
+-- Standardabstand zwischen zwei Raeumen
 mapperconf.scale = 5
                     ]]>
                 </script>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE MudletPackage>
+
+<!--
+     Benutzerdefinierte Einstellungen fuer die MG-Mudlet-Skripte.
+-->
+
+<MudletPackage version="1.0">
+    <!-- SCRIPTS -->
+    <ScriptPackage>
+        <ScriptGroup isActive="yes" isFolder="yes">
+            <name>Einstellungen</name>
+            <packageName></packageName>
+            <script></script>
+            <eventHandlerList/>
+            <Script isActive="yes" isFolder="no">
+                <name>Farben</name>
+                <packageName></packageName>
+                <script><![CDATA[
+farben = {}
+farben.vg = 
+  { komm = "cyan"
+    ebenen = "magenta",
+    info = "green",
+    alarm = "white",
+    script = "dark_green" }
+farben.hg = 
+  { komm = "black",
+    ebenen = "black",
+    info = "black", 
+    alarm = "red",
+    script = "black" }
+
+-- komm: Kommunikation wie teile-mit
+-- ebenen: Einfaerben der "normalen" Ebenen
+-- info: Einfaerben von Informationen des Muds (Status Gegner)
+-- alarm: Alarm-Nachrichten
+-- script: Nachrichten, die nicht vom Mud, sondern von einem Script stammen.
+
+-- Einstellungen fuer Farben Kampfscroll
+
+function msg (type, what)
+  -- setzt VG und HG je nach Typ der Kommunikation
+  local vg = farben.vg[type]
+  local hg = farben.hg[type]
+
+  if vg and hg then
+      cecho("<"..vg..":"..hg..">"..what)
+  else
+    echo(what)
+  end
+end
+                    ]]>
+                </script>
+                <eventHandlerList/>
+            </Script>
+            <Script isActive="yes" isFolder="no">
+                <name>Mapper</name>
+                <packageName></packageName>
+                <script><![CDATA[
+mapperconf = {}
+
+-------------------------------------------------------
+-- Benutzerdefinierte Einstellungen fuer den Mapper. --
+-------------------------------------------------------
+
+-- Farbe fuer Mitteilungen des Mappers
+mapperconf.color = "blue"
+                    ]]>
+                </script>
+            </Script>
+        </ScriptGroup>
+    </ScriptPackage>
+</MudletPackage>

--- a/settings.xml
+++ b/settings.xml
@@ -66,6 +66,7 @@ mapperconf = {}
 
 -- Farbe fuer Mitteilungen des Mappers
 mapperconf.color = "blue"
+mapperconf.scale = 5
                     ]]>
                 </script>
             </Script>

--- a/settings.xml
+++ b/settings.xml
@@ -19,7 +19,7 @@
                 <script><![CDATA[
 farben = {}
 farben.vg = 
-  { komm = "cyan"
+  { komm = "cyan",
     ebenen = "magenta",
     info = "green",
     alarm = "white",


### PR DESCRIPTION
Ich denke, es ist besser, die Dinge die der Benutzer konfigurieren kann/soll in ein separates Package zu packen, sonst muss man das bei jeder neuen Version wieder neu einstellen. Bei zukuenftigen Updates reicht es dann also, das neue Paket (z.b. krrrcks.xml) zu installieren, aber settings.xml zu behalten; so behaelt man dann auch seine Einstellungen.

Im Zuge dessen mache ich auch gleich mal den Standardabstand zwischen Raeumen konfigurierbar.
